### PR TITLE
fix: fix killall not found error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV	NVIDIA_DRIVER_CAPABILITIES=all
 RUN apt-get update && apt-get install -y \
     wget \
     tar \
+    psmisc \
     pciutils \
     && rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ docker run --runtime nvidia titan-node-pool -ethAddr <ETH_ADDRESS> -nickname <NI
  > If a discreet background operation suits your preferences, orchestrate it via Docker Compose:
 >
 >```bash
->docker-compose up -d
+>docker compose up -d
 >```
 >
 > During this process, update the [docker-compose.yml](docker-compose.yml) file with your precise ETH address, orchestrator secret and max sessions count.


### PR DESCRIPTION
This pull request ensures the `psmisc` system package is installed in the docker container, preventing the `/bin/sh: 1: killall: not found` error.
