### PR TITLE
chore(docker): update CUDA to V12

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.0.0-base-ubuntu22.04
+FROM nvidia/cuda:12.0.0-devel-ubuntu22.04
 
 ENV	NVIDIA_DRIVER_CAPABILITIES=all
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.8.0-base-ubuntu22.04
+FROM nvidia/cuda:12.0.0-base-ubuntu22.04
 
 ENV	NVIDIA_DRIVER_CAPABILITIES=all
 


### PR DESCRIPTION
This pull request updates the CUDA version to 12 since the upstream [go-livepeer](https://github.com/livepeer/go-livepeer) software was upgraded to this version.

@icsy7867 could you maybe update the image that is published on Dockerhub? Thanks 🙌!